### PR TITLE
Fix oscal generate issue

### DIFF
--- a/generator/reader.go
+++ b/generator/reader.go
@@ -24,6 +24,11 @@ func ReadCatalog(r io.Reader) (*catalog.Catalog, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot read oscal catalog from file %v,", err)
 	}
+
+	// oscalkit supports catalogs only at this point of time
+	if o.Catalog == nil {
+		return nil, fmt.Errorf("could not parse catalog")
+	}
 	return o.Catalog, nil
 
 }


### PR DESCRIPTION
when imports.href contains another profile, oscal generate command breaks as it currently does not support importing profiles.