### PR TITLE
Add implementation code generation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -48,6 +48,14 @@
   revision = "5d49c9dfc7836f0552e532b4b20caebf51b944e3"
 
 [[projects]]
+  digest = "1:7f569d906bdd20d906b606415b7d794f798f91a62fcfb6a4daa6d50690fb7a3f"
+  name = "github.com/satori/go.uuid"
+  packages = ["."]
+  pruneopts = ""
+  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
+  version = "v1.2.0"
+
+[[projects]]
   branch = "master"
   digest = "1:438d5957cf1c26ca62975dc4b1b59242acc9e527f39ed3f6cda57ee6d3653daf"
   name = "github.com/urfave/cli"
@@ -108,6 +116,7 @@
     "github.com/mitchellh/go-wordwrap",
     "github.com/santhosh-tekuri/jsonschema",
     "github.com/santhosh-tekuri/jsonschema/loader",
+    "github.com/satori/go.uuid",
     "github.com/urfave/cli",
     "gopkg.in/square/go-jose.v2",
     "gopkg.in/yaml.v2",

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -50,6 +50,7 @@ func Execute() error {
 		Validate,
 		Sign,
 		Generate,
+		Implementation,
 	}
 
 	return app.Run(os.Args)

--- a/cli/cmd/implementation.go
+++ b/cli/cmd/implementation.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"go/format"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+
+	"github.com/opencontrol/oscalkit/templates"
+
+	"github.com/opencontrol/oscalkit/impl"
+
+	"github.com/opencontrol/oscalkit/generator"
+	"github.com/urfave/cli"
+)
+
+var profile string
+var excelSheet string
+
+//Implementation generates implemntation
+var Implementation = cli.Command{
+	Name:  "implementation",
+	Usage: "generates go code for implementation against provided profile and excel sheet",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:        "profile, p",
+			Usage:       "profile to intersect against",
+			Destination: &profile,
+		},
+		cli.StringFlag{
+			Name:        "excel, e",
+			Usage:       "excel sheet to get component configs",
+			Destination: &excelSheet,
+		},
+		cli.StringFlag{
+			Name:        "output, o",
+			Usage:       "output filename",
+			Destination: &outputFileName,
+			Value:       "implementation.go",
+		},
+	},
+	Before: func(c *cli.Context) error {
+		if profile == "" {
+			return cli.NewExitError("oscalkit generate is missing the --profile flag", 1)
+		}
+		if excelSheet == "" {
+			return cli.NewExitError("oscalkit implementation is missing --excel flag", 1)
+		}
+		return nil
+	},
+	Action: func(c *cli.Context) error {
+
+		profileF, err := generator.GetFilePath(profile)
+		if err != nil {
+			return cli.NewExitError(err.Error(), 1)
+		}
+		f, err := os.Open(profileF)
+		if err != nil {
+			return cli.NewExitError(fmt.Sprintf("cannot open profile %v", err), 1)
+		}
+		defer f.Close()
+		profile, err := generator.ReadProfile(f)
+		if err != nil {
+			return err
+		}
+		excelF, err := generator.GetFilePath(excelSheet)
+		if err != nil {
+			return err
+		}
+		b, err := ioutil.ReadFile(excelF)
+		if err != nil {
+			return err
+		}
+
+		outputFile, err := os.Create(outputFileName)
+		if err != nil {
+			return fmt.Errorf("cannot create file for implementation: err: %v", err)
+		}
+		defer outputFile.Close()
+
+		var records [][]string
+		reader := bytes.NewReader(b)
+		r := csv.NewReader(reader)
+		for {
+			record, err := r.Read()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				log.Fatal(err)
+			}
+			records = append(records, record)
+		}
+
+		catalog := impl.NISTCatalog{ID: "NIST_SP-800-53"}
+		implementation := impl.GenerateImplementation(records, profile, &catalog)
+		t, err := templates.GetImplementationTemplate()
+		if err != nil {
+			return fmt.Errorf("cannot get implementation template err %v", err)
+		}
+		err = t.Execute(outputFile, implementation)
+		if err != nil {
+			return err
+		}
+		b, err = ioutil.ReadFile(outputFileName)
+		if err != nil {
+			return cli.NewExitError(fmt.Sprintf("cannot open %s file", outputFileName), 1)
+		}
+		b, err = format.Source(b)
+		if err != nil {
+			logrus.Warn(fmt.Sprintf("cannot format %s file", outputFileName))
+			return cli.NewExitError(err, 1)
+		}
+		err = ioutil.WriteFile(outputFileName, b, 0)
+		if err != nil {
+			return cli.NewExitError(fmt.Sprintf("cannot write formmated "), 1)
+		}
+		return nil
+	},
+}

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -206,7 +206,7 @@ func TestSubControlsMapping(t *testing.T) {
 func TestGetCatalogInvalidFilePath(t *testing.T) {
 
 	url := "http://[::1]a"
-	_, err := GetCatalogFilePath(url)
+	_, err := GetFilePath(url)
 	if err == nil {
 		t.Error("should fail")
 	}

--- a/generator/mapper.go
+++ b/generator/mapper.go
@@ -21,7 +21,7 @@ func CreateCatalogsFromProfile(profileArg *profile.Profile) ([]*catalog.Catalog,
 	for _, profileImport := range profileArg.Imports {
 		go func(profileImport profile.Import) {
 			//ForEach Import's Href, Fetch the Catalog JSON file
-			catalogReference, err := GetCatalogFilePath(profileImport.Href.String())
+			catalogReference, err := GetFilePath(profileImport.Href.String())
 			if err != nil {
 				logrus.Errorf("invalid file path: %v", err)
 				catalogChan <- nil

--- a/generator/reader.go
+++ b/generator/reader.go
@@ -40,18 +40,21 @@ func ReadProfile(r io.Reader) (*profile.Profile, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot read oscal profile from file. err: %v,", err)
 	}
+	if o.Profile == nil {
+		return nil, fmt.Errorf("unable to marshall profile")
+	}
 	return o.Profile, nil
 }
 
-//GetCatalogFilePath GetCatalogFilePath
-func GetCatalogFilePath(catalogURL string) (string, error) {
-	uri, err := url.Parse(catalogURL)
+//GetFilePath GetFilePath
+func GetFilePath(URL string) (string, error) {
+	uri, err := url.Parse(URL)
 	if err != nil {
 		return "", fmt.Errorf("invalid URL pattern %v", err)
 	}
 
 	if !isHTTPResource(uri) {
-		return GetAbsolutePath(catalogURL)
+		return GetAbsolutePath(URL)
 	}
 	body, err := fetchFromHTTPResource(uri)
 	if err != nil {

--- a/impl/impl_test.go
+++ b/impl/impl_test.go
@@ -1,0 +1,90 @@
+package impl
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/opencontrol/oscalkit/types/oscal/catalog"
+	"github.com/opencontrol/oscalkit/types/oscal/profile"
+)
+
+const (
+	temporaryProfileID = "oscaltestprofile"
+	catalogRef         = "https://raw.githubusercontent.com/usnistgov/OSCAL/master/content/nist.gov/SP800-53/rev4/NIST_SP-800-53_rev4_catalog.xml"
+)
+
+func TestGenerateImplementation(t *testing.T) {
+
+	components := []string{"CompA", "CompB", "CompC"}
+	controls := []string{"ac-2", "ac-2.2", "ac-4"}
+	ComponentDetails := [][]string{
+		[]string{controls[0], fmt.Sprintf("%s|%s", components[0], components[1]), "2-Narrative"},
+		[]string{controls[1], fmt.Sprintf("%s|%s", components[0], components[1]), "2.2-Narrative"},
+		[]string{controls[2], "CompC", "4-Narrative"},
+	}
+	csvs := make([][]string, TotalControlsInExcel)
+	for i := range csvs {
+		csvs[i] = make([]string, 20)
+	}
+	for i, x := range ComponentDetails {
+		csvs[i+RowIndex][ControlIndex] = x[0]
+		csvs[i+RowIndex][ComponentNameIndex] = x[1]
+		csvs[i+RowIndex][NarrativeIndex] = x[2]
+	}
+
+	p := profile.Profile{
+		ID: temporaryProfileID,
+		Imports: []profile.Import{
+			profile.Import{
+				Href: &catalog.Href{
+					URL: func() *url.URL {
+						uri, _ := url.Parse(catalogRef)
+						return uri
+					}(),
+				},
+				Include: &profile.Include{
+					IdSelectors: []profile.Call{
+						profile.Call{
+							ControlId: "ac-2",
+						},
+						profile.Call{
+							ControlId: "ac-4",
+						},
+						profile.Call{
+							SubcontrolId: "ac-4.2",
+						},
+					},
+				},
+			},
+		},
+		Modify: &profile.Modify{
+			ParamSettings: []profile.SetParam{
+				profile.SetParam{
+					Id:          "ac-2_prm",
+					Constraints: []catalog.Constraint{catalog.Constraint{Value: "some constraint"}},
+				},
+				profile.SetParam{
+					Id:          "ac-2_prm_obj",
+					Constraints: []catalog.Constraint{catalog.Constraint{Value: "some constraint"}},
+				},
+				profile.SetParam{
+					Id:          "",
+					Constraints: []catalog.Constraint{},
+				},
+				profile.SetParam{
+					Id:          "ac-4_prm",
+					Constraints: []catalog.Constraint{},
+				},
+			},
+		},
+	}
+	i := GenerateImplementation(csvs, &p, &NISTCatalog{"NISTSP80053"})
+	if len(i.ComponentDefinitions[0].ComponentConfigurations) != len(components) {
+		t.Error("mismatch number of components")
+	}
+	if len(i.ComponentDefinitions[0].ControlImplementations[0].ControlIds) != len(controls) {
+		t.Error("mismatch number of controls")
+	}
+
+}

--- a/impl/implementation.go
+++ b/impl/implementation.go
@@ -1,0 +1,275 @@
+package impl
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/opencontrol/oscalkit/types/oscal/implementation"
+	"github.com/opencontrol/oscalkit/types/oscal/profile"
+	uuid "github.com/satori/go.uuid"
+)
+
+const (
+	//TotalControlsInExcel the total number of controls in the excel sheet
+	TotalControlsInExcel = 264
+	//ComponentNameIndex The Column at which name of the component configuration is present
+	ComponentNameIndex = 15
+	//NarrativeIndex The Column at which narrative of the component configuration is present
+	NarrativeIndex = 16
+	//ControlIndex Column at which control is present in the excel sheet
+	ControlIndex = 2
+	//RowIndex Starting point for valid rows (neglects titles)
+	RowIndex = 3
+)
+
+type guidMap map[string]uuid.UUID
+type cdMap map[string]implementation.ComponentDefinition
+
+//GenerateImplementation generates implementation from component excel sheet
+func GenerateImplementation(CSVS [][]string, p *profile.Profile, c Catalog) implementation.Implementation {
+
+	ComponentDefinitonMap := make(map[string]implementation.ComponentDefinition)
+	checkAgainstGUUID := make(map[string]uuid.UUID)
+
+	for i := RowIndex; i < TotalControlsInExcel; i++ {
+		applicableControl := CSVS[i][ControlIndex]
+		if applicableControl == "" {
+			continue
+		}
+		applicableNarrative := CSVS[i][NarrativeIndex]
+		ListOfComponentConfigName := strings.Split(CSVS[i][ComponentNameIndex], "|")
+		for _, componentConfigName := range ListOfComponentConfigName {
+			componentConfigName = strings.TrimSpace(componentConfigName)
+			if componentConfigName == "" {
+				continue
+			}
+			if _, ok := ComponentDefinitonMap[componentConfigName]; !ok {
+				CreateComponentDefinition(checkAgainstGUUID, ComponentDefinitonMap, componentConfigName, p, c, applicableControl, applicableNarrative)
+			} else {
+				securityCheck := ComponentDefinitonMap[componentConfigName]
+				guid := checkAgainstGUUID[componentConfigName]
+				ComponentDefinitonMap[componentConfigName] = AppendParameterInImplementation(securityCheck, guid, p, c, applicableControl)
+			}
+		}
+	}
+	return CompileImplemenatation(ComponentDefinitonMap, CSVS, c, p)
+
+}
+
+//CreateComponentDefinition creates a component definition
+func CreateComponentDefinition(gm guidMap, cdm cdMap, componentConfName string, p *profile.Profile, c Catalog, control, narrative string) {
+
+	componentConfGUID := uuid.NewV4()
+	gm[componentConfName] = componentConfGUID
+	controlConfiguration := implementation.ControlConfiguration{
+		ConfigurationIDRef: componentConfGUID.String(),
+	}
+	var parameters []implementation.Parameter
+	if p.Modify != nil {
+		for _, param := range p.Modify.ParamSettings {
+			if param.Id == "" {
+				continue
+			}
+			if c.GetControl(param.Id) == c.GetControl(control) {
+				if existsInParams(param.Id, parameters) {
+					continue
+				}
+				x := GenerateImplementationParamter(param)
+				parameters = append(parameters, x)
+			}
+		}
+	}
+
+	controlConfiguration.Parameters = parameters
+	cdm[componentConfName] = implementation.ComponentDefinition{
+		ComponentConfigurations: []*implementation.ComponentConfiguration{
+			CreateComponentConfiguration(componentConfGUID, componentConfName, narrative),
+		},
+		ImplementsProfiles: []*implementation.ImplementsProfile{
+			&implementation.ImplementsProfile{
+				ProfileID: p.ID,
+				ControlConfigurations: []implementation.ControlConfiguration{
+					controlConfiguration,
+				},
+			},
+		},
+	}
+
+}
+
+//CreateComponentConfiguration creates component configuration
+func CreateComponentConfiguration(guid uuid.UUID, componentConfName, narrative string) *implementation.ComponentConfiguration {
+
+	return &implementation.ComponentConfiguration{
+		ID:          guid.String(),
+		Name:        componentConfName,
+		Description: narrative,
+		ConfigurableValues: []implementation.ConfigurableValue{
+			implementation.ConfigurableValue{
+				ValueID: uuid.NewV4().String(),
+				Value:   0,
+			},
+		},
+	}
+}
+
+//AppendParameterInImplementation Appends parameter in the relative guid
+func AppendParameterInImplementation(cd implementation.ComponentDefinition, guid uuid.UUID, p *profile.Profile, c Catalog, control string) implementation.ComponentDefinition {
+	for i := range cd.ImplementsProfiles {
+		for j := range cd.ImplementsProfiles[i].ControlConfigurations {
+			if guid.String() == cd.ImplementsProfiles[i].ControlConfigurations[j].ConfigurationIDRef {
+				for _, param := range p.Modify.ParamSettings {
+					if param.Id == "" {
+						continue
+					}
+					if existsInParams(param.Id, cd.ImplementsProfiles[i].ControlConfigurations[j].Parameters) {
+						continue
+					}
+					if c.GetControl(param.Id) == c.GetControl(control) {
+						x := GenerateImplementationParamter(param)
+						cd.ImplementsProfiles[i].ControlConfigurations[j].Parameters = append(cd.ImplementsProfiles[i].ControlConfigurations[j].Parameters, x)
+					}
+				}
+			}
+		}
+	}
+	return cd
+
+}
+
+//CompileImplemenatation compiles all checks from maps to implementation json
+func CompileImplemenatation(cd cdMap, CSVS [][]string, cat Catalog, p *profile.Profile) implementation.Implementation {
+	return implementation.Implementation{
+		ComponentDefinitions: []implementation.ComponentDefinition{
+			implementation.ComponentDefinition{
+				ComponentConfigurations: func() []*implementation.ComponentConfiguration {
+					var arr []*implementation.ComponentConfiguration
+					for _, v := range cd {
+						for _, x := range v.ComponentConfigurations {
+							arr = append(arr, x)
+						}
+					}
+					return arr
+				}(),
+				ControlImplementations: func() []*implementation.ControlImplementation {
+					arr := []*implementation.ControlImplementation{
+						&implementation.ControlImplementation{
+							ControlIds: []implementation.ControlId{},
+						},
+					}
+					for i := 3; i < TotalControlsInExcel; i++ {
+						if CSVS[i][ControlIndex] == "" {
+							continue
+						}
+						c := strings.ToLower(CSVS[i][ControlIndex])
+						if cat.isSubControl(c) {
+							arr[0].ControlIds = append(arr[0].ControlIds, implementation.ControlId{
+								ControlID:    "",
+								ItemID:       c,
+								CatalogIDRef: cat.GetID(),
+							})
+							continue
+						}
+						arr[0].ControlIds = append(arr[0].ControlIds, implementation.ControlId{
+							ControlID:    cat.GetControl(CSVS[i][ControlIndex]),
+							ItemID:       "",
+							CatalogIDRef: cat.GetID(),
+						})
+					}
+					for _, def := range cd {
+						for _, ci := range def.ImplementsProfiles {
+							for _, cc := range ci.ControlConfigurations {
+								arr[0].ControlConfigurations = append(arr[0].ControlConfigurations, cc)
+							}
+						}
+					}
+					return arr
+				}(),
+				ImplementsProfiles: []*implementation.ImplementsProfile{
+					&implementation.ImplementsProfile{
+						ProfileID: p.ID,
+						ControlConfigurations: func() []implementation.ControlConfiguration {
+							var arr []implementation.ControlConfiguration
+							for _, v := range cd {
+								for _, x := range v.ImplementsProfiles {
+									for _, y := range x.ControlConfigurations {
+										arr = append(arr, y)
+									}
+								}
+							}
+							return arr
+						}(),
+					},
+				},
+			},
+		},
+	}
+}
+
+//Catalog catalog interface to determine control id pattern
+type Catalog interface {
+	GetControl(p string) string
+	isSubControl(s string) bool
+	GetID() string
+}
+
+//NISTCatalog NIST80053 catalog
+type NISTCatalog struct {
+	ID string
+}
+
+func (n *NISTCatalog) GetID() string {
+	return n.ID
+}
+
+//GetControl GetControl
+func (*NISTCatalog) GetControl(p string) string {
+
+	p = strings.ToLower(p)
+	x := strings.Split(p, ".")
+	y := strings.Split(x[0], " ")
+	z := strings.Split(y[0], "_")
+	control := z[0]
+	controlLen := len(control)
+	isControl, _ := regexp.MatchString("([a-z][a-z]-[0-9]*)$", control)
+	if !isControl {
+		control = control[:controlLen-1]
+	}
+	return control
+}
+
+func (*NISTCatalog) isSubControl(s string) bool {
+	substrings := []string{" ", "(", "."}
+	for _, substr := range substrings {
+		if strings.Contains(s, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+//GenerateImplementationParamter GenerateImplementationParamter
+func GenerateImplementationParamter(param profile.SetParam) implementation.Parameter {
+	return implementation.Parameter{
+		ParameterID: param.Id,
+		Value: func() string {
+			str := ""
+			for _, x := range param.Constraints {
+				str += x.Value + " "
+			}
+			return str
+		}(),
+		Guidance: "{{guidance}}",
+		ValueID:  "{{valueId}}",
+	}
+}
+
+func existsInParams(pId string, p []implementation.Parameter) bool {
+	for _, x := range p {
+		if x.ParameterID == pId {
+			return true
+		}
+	}
+	return false
+
+}

--- a/impl/implementation.go
+++ b/impl/implementation.go
@@ -13,9 +13,9 @@ const (
 	//TotalControlsInExcel the total number of controls in the excel sheet
 	TotalControlsInExcel = 264
 	//ComponentNameIndex The Column at which name of the component configuration is present
-	ComponentNameIndex = 15
+	ComponentNameIndex = 14
 	//NarrativeIndex The Column at which narrative of the component configuration is present
-	NarrativeIndex = 16
+	NarrativeIndex = 15
 	//ControlIndex Column at which control is present in the excel sheet
 	ControlIndex = 2
 	//RowIndex Starting point for valid rows (neglects titles)
@@ -107,7 +107,7 @@ func CreateComponentConfiguration(guid uuid.UUID, componentConfName, narrative s
 		ConfigurableValues: []implementation.ConfigurableValue{
 			implementation.ConfigurableValue{
 				ValueID: uuid.NewV4().String(),
-				Value:   0,
+				Value:   "0",
 			},
 		},
 	}
@@ -164,7 +164,7 @@ func CompileImplemenatation(cd cdMap, CSVS [][]string, cat Catalog, p *profile.P
 						c := strings.ToLower(CSVS[i][ControlIndex])
 						if cat.isSubControl(c) {
 							arr[0].ControlIds = append(arr[0].ControlIds, implementation.ControlId{
-								ControlID:    "",
+								ControlID:    cat.GetControl(c),
 								ItemID:       c,
 								CatalogIDRef: cat.GetID(),
 							})
@@ -252,15 +252,16 @@ func (*NISTCatalog) isSubControl(s string) bool {
 func GenerateImplementationParamter(param profile.SetParam) implementation.Parameter {
 	return implementation.Parameter{
 		ParameterID: param.Id,
-		Value: func() string {
-			str := ""
+		PossibleValues: func() []string {
+			values := []string{}
 			for _, x := range param.Constraints {
-				str += x.Value + " "
+				values = append(values, x.Value)
 			}
-			return str
+			return values
 		}(),
-		Guidance: "{{guidance}}",
-		ValueID:  "{{valueId}}",
+		Guidance:     "{{guidance}}",
+		ValueID:      "{{valueId}}",
+		DefaultValue: "{{defaultValue}}",
 	}
 }
 

--- a/templates/implementation.go
+++ b/templates/implementation.go
@@ -29,7 +29,7 @@ var ImplementationGenerated = implementation.Implementation{
 							ConfigurableValues: []implementation.ConfigurableValue{
 								{{range .ConfigurableValues}}
 									implementation.ConfigurableValue{
-											Value:   {{.Value}},
+											Value:   "{{.Value}}",
 											ValueID: "{{.ValueID}}",
 									},
 								{{end}}
@@ -48,10 +48,15 @@ var ImplementationGenerated = implementation.Implementation{
 										Parameters:         []implementation.Parameter{
 											{{range .Parameters}}
 											implementation.Parameter{
-											Guidance: "{{.Guidance}}",
-											ParameterID: "{{.ParameterID}}",
-											Value: "{{.Value}}",
-											ValueID: "{{.ValueID}}",
+												Guidance: "{{.Guidance}}",
+												ParameterID: "{{.ParameterID}}",
+												ValueID: "{{.ValueID}}",
+												DefaultValue: "{{.PossibleValues}}",
+												PossibleValues: []string{
+													{{range .PossibleValues}}
+														"{{.}}",
+													{{end}}
+												},												
 											},
 											{{end}}
 										},
@@ -81,10 +86,15 @@ var ImplementationGenerated = implementation.Implementation{
 										Parameters:         []implementation.Parameter{
 											{{range .Parameters}}
 											implementation.Parameter{
-											Guidance: "{{.Guidance}}",
-											ParameterID: "{{.ParameterID}}",
-											Value: "{{.Value}}",
-											ValueID: "{{.ValueID}}",
+												Guidance: "{{.Guidance}}",
+												ParameterID: "{{.ParameterID}}",
+												ValueID: "{{.ValueID}}",
+												DefaultValue: "{{.DefaultValue}}",
+												PossibleValues: []string{
+													{{range .PossibleValues}}
+														"{{.}}",
+													{{end}}
+												},
 											},
 											{{end}}
 										},

--- a/templates/implementation.go
+++ b/templates/implementation.go
@@ -1,0 +1,100 @@
+package templates
+
+import "html/template"
+
+//GetImplementationTemplate gets implementation template for implementation go struct file
+func GetImplementationTemplate() (*template.Template, error) {
+	return template.New("").Parse(implementationTemplate)
+}
+
+const implementationTemplate = `package oscalkit
+
+import (
+	"github.com/opencontrol/oscalkit/types/oscal/implementation"
+)
+
+var ImplementationGenerated = implementation.Implementation{
+	Capabilities: implementation.Capabilities{},
+	ComponentDefinitions: []implementation.ComponentDefinition{
+		{{range .ComponentDefinitions}}
+		implementation.ComponentDefinition{
+			ComponentConfigurations: []*implementation.ComponentConfiguration{
+					{{range .ComponentConfigurations}}
+					&implementation.ComponentConfiguration{
+							ID:                     ` + "`{{.ID}}`" + `,
+							Name:                   ` + "`{{.Name}}`" + `,
+							Description:            ` + "`{{.Description}}`" + `,
+							ProvisioningMechanisms: []implementation.Mechanism{},
+							ValidationMechanisms:   []implementation.Mechanism{},
+							ConfigurableValues: []implementation.ConfigurableValue{
+								{{range .ConfigurableValues}}
+									implementation.ConfigurableValue{
+											Value:   {{.Value}},
+											ValueID: "{{.ValueID}}",
+									},
+								{{end}}
+							},				
+						},
+					{{end}}
+				},
+				ImplementsProfiles: []*implementation.ImplementsProfile{
+					{{range .ImplementsProfiles}}
+						&implementation.ImplementsProfile{
+							ProfileID: "{{.ProfileID}}",
+							ControlConfigurations: []implementation.ControlConfiguration{
+								{{range .ControlConfigurations}}
+									implementation.ControlConfiguration{
+										ConfigurationIDRef: "{{.ConfigurationIDRef}}",
+										Parameters:         []implementation.Parameter{
+											{{range .Parameters}}
+											implementation.Parameter{
+											Guidance: "{{.Guidance}}",
+											ParameterID: "{{.ParameterID}}",
+											Value: "{{.Value}}",
+											ValueID: "{{.ValueID}}",
+											},
+											{{end}}
+										},
+									},
+								{{end}}
+							},
+						},
+					{{end}}
+				},
+				ControlImplementations: []*implementation.ControlImplementation{
+					{{range .ControlImplementations}}
+						&implementation.ControlImplementation{
+							ID: "{{.ID}}",
+							ControlIds: []implementation.ControlId{
+								{{range .ControlIds}}
+								implementation.ControlId{
+										CatalogIDRef: "{{.CatalogIDRef}}",
+										ControlID:	 ` + "`{{.ControlID}}`" + `,
+										ItemID: 	 ` + "`{{.ItemID}}`" + `,
+									},
+								{{end}}
+							},
+							ControlConfigurations: []implementation.ControlConfiguration{
+								{{range .ControlConfigurations}}
+									implementation.ControlConfiguration{
+										ConfigurationIDRef: "{{.ConfigurationIDRef}}",
+										Parameters:         []implementation.Parameter{
+											{{range .Parameters}}
+											implementation.Parameter{
+											Guidance: "{{.Guidance}}",
+											ParameterID: "{{.ParameterID}}",
+											Value: "{{.Value}}",
+											ValueID: "{{.ValueID}}",
+											},
+											{{end}}
+										},
+									},
+								{{end}}
+							},
+						},
+					{{end}}
+				},
+			},
+		{{end}}
+	},
+}`

--- a/types/oscal/implementation/implementation.go
+++ b/types/oscal/implementation/implementation.go
@@ -22,7 +22,7 @@ type Label struct {
 
 type ConfigurableValue struct {
 	ValueID string `xml:"value-id,attr,omitempty" json:"valueId"`
-	Value   int    `xml:"value,attr,omitempty" json:"value"`
+	Value   string `xml:"value,attr,omitempty" json:"value"`
 }
 
 type ComponentConfiguration struct {
@@ -36,10 +36,12 @@ type ComponentConfiguration struct {
 }
 
 type Parameter struct {
-	ParameterID string `xml:"parameter-id,attr,omitempty" json:"parameterId"`
-	ValueID     string `xml:"value-id,attr,omitempty" json:"valueId"`
-	Value       string `xml:"value,attr,omitempty" json:"value"`
-	Guidance    string `xml:"guidance,attr,omitempty" json:"guidance"`
+	ParameterID    string        `xml:"parameter-id,attr,omitempty" json:"parameterId,omitempty"`
+	ValueID        string        `xml:"value-id,attr,omitempty" json:"valueId,omitempty"`
+	Guidance       string        `xml:"guidance,attr,omitempty" json:"guidance,omitempty"`
+	AssessedValue  AssessedValue `xml:"assessed-value,attr,omitempty" json:"assessedValue,omitempty"`
+	PossibleValues []string      `xml:"possbile-values,attr,omitempty" json:"possibleValues,omitempty"`
+	DefaultValue   string        `xml:"default-value,attr,omitempty" json:"defaultValue,omitempty"`
 }
 
 type ImplementsProfile struct {
@@ -53,9 +55,10 @@ type ControlConfiguration struct {
 }
 
 type ControlId struct {
-	CatalogIDRef string `xml:"control-id-ref,attr,omitempty" json:"catalogIdRef,omitempty"`
-	ControlID    string `xml:"control-id,attr,omitempty" json:"controlId,omitempty"`
-	ItemID       string `xml:"item-id,attr,omitempty" json:"itemId,omitempty"`
+	CatalogIDRef   string         `xml:"control-id-ref,attr,omitempty" json:"catalogIdRef,omitempty"`
+	ControlID      string         `xml:"control-id,attr,omitempty" json:"controlId,omitempty"`
+	ItemID         string         `xml:"item-id,attr,omitempty" json:"itemId,omitempty"`
+	AssessmentData AssessmentData `xml:"assesment-data,attr,omitempty" json:"assesmentData,attr,omitempty"`
 }
 
 type Relationship struct {
@@ -88,3 +91,23 @@ type Implementation struct {
 type Capabilities struct{}
 
 type ComponentSpecifications struct{}
+
+type AssessmentData struct {
+	AssessmentID      string             `xml:"assessment-id,attr,omitempty" json:"assessmentId,omitempty"`
+	Guidance          string             `xml:"guidance,attr,omitempty" json:"guidance,omitempty"`
+	ValidationResults []ValidationResult `xml:"validation-results,attr,omitempty" json:"validationResults,omitempty"`
+}
+
+type ValidationResult struct {
+	ValidationMechanismRefID string `xml:"validation-mechanism-refid,attr,omitempty" json:"validationMechanismRefId,omitempty"`
+	Output                   string `xml:"output,attr,omitempty" json:"output,omitempty"`
+	Compliant                bool   `xml:"compliant,attr,omitempty" json:"compliant,omitempty"`
+}
+
+//AssessedValue AssessedValue
+type AssessedValue struct {
+	AssessmentID string `xml:"assessment-id,attr,omitempty" json:"assessmentId,omitempty"`
+	Output       string `xml:"output,attr,omitempty" json:"output,omitempty"`
+	Compliant    bool   `xml:"compliant,attr,omitempty" json:"compliant,omitempty"`
+	Value        string `xml:"value,attr,omitempty" json:"value"`
+}

--- a/types/oscal/profile/profile.go
+++ b/types/oscal/profile/profile.go
@@ -8,6 +8,7 @@ import (
 
 // Each OSCAL profile is defined by a Profile element
 type Profile struct {
+	ID      string   `xml:"id,attr,omitempty" json:"id,omitempty"`
 	XMLName xml.Name `xml:"http://csrc.nist.gov/ns/oscal/1.0 profile" json:"-"`
 	Merge   *Merge   `xml:"merge,omitempty" json:"merge,omitempty"`
 	Modify  *Modify  `xml:"modify,omitempty" json:"modify,omitempty"`

--- a/vendor/github.com/satori/go.uuid/.travis.yml
+++ b/vendor/github.com/satori/go.uuid/.travis.yml
@@ -1,0 +1,23 @@
+language: go
+sudo: false
+go:
+    - 1.2
+    - 1.3
+    - 1.4
+    - 1.5
+    - 1.6
+    - 1.7
+    - 1.8
+    - 1.9
+    - tip
+matrix:
+    allow_failures:
+        - go: tip
+    fast_finish: true
+before_install:
+    - go get github.com/mattn/goveralls
+    - go get golang.org/x/tools/cmd/cover
+script:
+    - $HOME/gopath/bin/goveralls -service=travis-ci
+notifications:
+    email: false

--- a/vendor/github.com/satori/go.uuid/LICENSE
+++ b/vendor/github.com/satori/go.uuid/LICENSE
@@ -1,0 +1,20 @@
+Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/satori/go.uuid/README.md
+++ b/vendor/github.com/satori/go.uuid/README.md
@@ -1,0 +1,65 @@
+# UUID package for Go language
+
+[![Build Status](https://travis-ci.org/satori/go.uuid.png?branch=master)](https://travis-ci.org/satori/go.uuid)
+[![Coverage Status](https://coveralls.io/repos/github/satori/go.uuid/badge.svg?branch=master)](https://coveralls.io/github/satori/go.uuid)
+[![GoDoc](http://godoc.org/github.com/satori/go.uuid?status.png)](http://godoc.org/github.com/satori/go.uuid)
+
+This package provides pure Go implementation of Universally Unique Identifier (UUID). Supported both creation and parsing of UUIDs.
+
+With 100% test coverage and benchmarks out of box.
+
+Supported versions:
+* Version 1, based on timestamp and MAC address (RFC 4122)
+* Version 2, based on timestamp, MAC address and POSIX UID/GID (DCE 1.1)
+* Version 3, based on MD5 hashing (RFC 4122)
+* Version 4, based on random numbers (RFC 4122)
+* Version 5, based on SHA-1 hashing (RFC 4122)
+
+## Installation
+
+Use the `go` command:
+
+	$ go get github.com/satori/go.uuid
+
+## Requirements
+
+UUID package requires Go >= 1.2.
+
+## Example
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/satori/go.uuid"
+)
+
+func main() {
+	// Creating UUID Version 4
+	u1 := uuid.NewV4()
+	fmt.Printf("UUIDv4: %s\n", u1)
+
+	// Parsing UUID from string input
+	u2, err := uuid.FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	if err != nil {
+		fmt.Printf("Something gone wrong: %s", err)
+	}
+	fmt.Printf("Successfully parsed: %s", u2)
+}
+```
+
+## Documentation
+
+[Documentation](http://godoc.org/github.com/satori/go.uuid) is hosted at GoDoc project.
+
+## Links
+* [RFC 4122](http://tools.ietf.org/html/rfc4122)
+* [DCE 1.1: Authentication and Security Services](http://pubs.opengroup.org/onlinepubs/9696989899/chap5.htm#tagcjh_08_02_01_01)
+
+## Copyright
+
+Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>.
+
+UUID package released under MIT License.
+See [LICENSE](https://github.com/satori/go.uuid/blob/master/LICENSE) for details.

--- a/vendor/github.com/satori/go.uuid/codec.go
+++ b/vendor/github.com/satori/go.uuid/codec.go
@@ -1,0 +1,206 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package uuid
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+)
+
+// FromBytes returns UUID converted from raw byte slice input.
+// It will return error if the slice isn't 16 bytes long.
+func FromBytes(input []byte) (u UUID, err error) {
+	err = u.UnmarshalBinary(input)
+	return
+}
+
+// FromBytesOrNil returns UUID converted from raw byte slice input.
+// Same behavior as FromBytes, but returns a Nil UUID on error.
+func FromBytesOrNil(input []byte) UUID {
+	uuid, err := FromBytes(input)
+	if err != nil {
+		return Nil
+	}
+	return uuid
+}
+
+// FromString returns UUID parsed from string input.
+// Input is expected in a form accepted by UnmarshalText.
+func FromString(input string) (u UUID, err error) {
+	err = u.UnmarshalText([]byte(input))
+	return
+}
+
+// FromStringOrNil returns UUID parsed from string input.
+// Same behavior as FromString, but returns a Nil UUID on error.
+func FromStringOrNil(input string) UUID {
+	uuid, err := FromString(input)
+	if err != nil {
+		return Nil
+	}
+	return uuid
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+// The encoding is the same as returned by String.
+func (u UUID) MarshalText() (text []byte, err error) {
+	text = []byte(u.String())
+	return
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+// Following formats are supported:
+//   "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+//   "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
+//   "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+//   "6ba7b8109dad11d180b400c04fd430c8"
+// ABNF for supported UUID text representation follows:
+//   uuid := canonical | hashlike | braced | urn
+//   plain := canonical | hashlike
+//   canonical := 4hexoct '-' 2hexoct '-' 2hexoct '-' 6hexoct
+//   hashlike := 12hexoct
+//   braced := '{' plain '}'
+//   urn := URN ':' UUID-NID ':' plain
+//   URN := 'urn'
+//   UUID-NID := 'uuid'
+//   12hexoct := 6hexoct 6hexoct
+//   6hexoct := 4hexoct 2hexoct
+//   4hexoct := 2hexoct 2hexoct
+//   2hexoct := hexoct hexoct
+//   hexoct := hexdig hexdig
+//   hexdig := '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' |
+//             'a' | 'b' | 'c' | 'd' | 'e' | 'f' |
+//             'A' | 'B' | 'C' | 'D' | 'E' | 'F'
+func (u *UUID) UnmarshalText(text []byte) (err error) {
+	switch len(text) {
+	case 32:
+		return u.decodeHashLike(text)
+	case 36:
+		return u.decodeCanonical(text)
+	case 38:
+		return u.decodeBraced(text)
+	case 41:
+		fallthrough
+	case 45:
+		return u.decodeURN(text)
+	default:
+		return fmt.Errorf("uuid: incorrect UUID length: %s", text)
+	}
+}
+
+// decodeCanonical decodes UUID string in format
+// "6ba7b810-9dad-11d1-80b4-00c04fd430c8".
+func (u *UUID) decodeCanonical(t []byte) (err error) {
+	if t[8] != '-' || t[13] != '-' || t[18] != '-' || t[23] != '-' {
+		return fmt.Errorf("uuid: incorrect UUID format %s", t)
+	}
+
+	src := t[:]
+	dst := u[:]
+
+	for i, byteGroup := range byteGroups {
+		if i > 0 {
+			src = src[1:] // skip dash
+		}
+		_, err = hex.Decode(dst[:byteGroup/2], src[:byteGroup])
+		if err != nil {
+			return
+		}
+		src = src[byteGroup:]
+		dst = dst[byteGroup/2:]
+	}
+
+	return
+}
+
+// decodeHashLike decodes UUID string in format
+// "6ba7b8109dad11d180b400c04fd430c8".
+func (u *UUID) decodeHashLike(t []byte) (err error) {
+	src := t[:]
+	dst := u[:]
+
+	if _, err = hex.Decode(dst, src); err != nil {
+		return err
+	}
+	return
+}
+
+// decodeBraced decodes UUID string in format
+// "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}" or in format
+// "{6ba7b8109dad11d180b400c04fd430c8}".
+func (u *UUID) decodeBraced(t []byte) (err error) {
+	l := len(t)
+
+	if t[0] != '{' || t[l-1] != '}' {
+		return fmt.Errorf("uuid: incorrect UUID format %s", t)
+	}
+
+	return u.decodePlain(t[1 : l-1])
+}
+
+// decodeURN decodes UUID string in format
+// "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8" or in format
+// "urn:uuid:6ba7b8109dad11d180b400c04fd430c8".
+func (u *UUID) decodeURN(t []byte) (err error) {
+	total := len(t)
+
+	urn_uuid_prefix := t[:9]
+
+	if !bytes.Equal(urn_uuid_prefix, urnPrefix) {
+		return fmt.Errorf("uuid: incorrect UUID format: %s", t)
+	}
+
+	return u.decodePlain(t[9:total])
+}
+
+// decodePlain decodes UUID string in canonical format
+// "6ba7b810-9dad-11d1-80b4-00c04fd430c8" or in hash-like format
+// "6ba7b8109dad11d180b400c04fd430c8".
+func (u *UUID) decodePlain(t []byte) (err error) {
+	switch len(t) {
+	case 32:
+		return u.decodeHashLike(t)
+	case 36:
+		return u.decodeCanonical(t)
+	default:
+		return fmt.Errorf("uuid: incorrrect UUID length: %s", t)
+	}
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface.
+func (u UUID) MarshalBinary() (data []byte, err error) {
+	data = u.Bytes()
+	return
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+// It will return error if the slice isn't 16 bytes long.
+func (u *UUID) UnmarshalBinary(data []byte) (err error) {
+	if len(data) != Size {
+		err = fmt.Errorf("uuid: UUID must be exactly 16 bytes long, got %d bytes", len(data))
+		return
+	}
+	copy(u[:], data)
+
+	return
+}

--- a/vendor/github.com/satori/go.uuid/codec_test.go
+++ b/vendor/github.com/satori/go.uuid/codec_test.go
@@ -1,0 +1,248 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package uuid
+
+import (
+	"bytes"
+
+	. "gopkg.in/check.v1"
+)
+
+type codecTestSuite struct{}
+
+var _ = Suite(&codecTestSuite{})
+
+func (s *codecTestSuite) TestFromBytes(c *C) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b1 := []byte{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	u1, err := FromBytes(b1)
+	c.Assert(err, IsNil)
+	c.Assert(u1, Equals, u)
+
+	b2 := []byte{}
+	_, err = FromBytes(b2)
+	c.Assert(err, NotNil)
+}
+
+func (s *codecTestSuite) BenchmarkFromBytes(c *C) {
+	bytes := []byte{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	for i := 0; i < c.N; i++ {
+		FromBytes(bytes)
+	}
+}
+
+func (s *codecTestSuite) TestMarshalBinary(c *C) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b1 := []byte{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	b2, err := u.MarshalBinary()
+	c.Assert(err, IsNil)
+	c.Assert(bytes.Equal(b1, b2), Equals, true)
+}
+
+func (s *codecTestSuite) BenchmarkMarshalBinary(c *C) {
+	u := NewV4()
+	for i := 0; i < c.N; i++ {
+		u.MarshalBinary()
+	}
+}
+
+func (s *codecTestSuite) TestUnmarshalBinary(c *C) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b1 := []byte{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	u1 := UUID{}
+	err := u1.UnmarshalBinary(b1)
+	c.Assert(err, IsNil)
+	c.Assert(u1, Equals, u)
+
+	b2 := []byte{}
+	u2 := UUID{}
+	err = u2.UnmarshalBinary(b2)
+	c.Assert(err, NotNil)
+}
+
+func (s *codecTestSuite) TestFromString(c *C) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	s1 := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	s2 := "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}"
+	s3 := "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	s4 := "6ba7b8109dad11d180b400c04fd430c8"
+	s5 := "urn:uuid:6ba7b8109dad11d180b400c04fd430c8"
+
+	_, err := FromString("")
+	c.Assert(err, NotNil)
+
+	u1, err := FromString(s1)
+	c.Assert(err, IsNil)
+	c.Assert(u1, Equals, u)
+
+	u2, err := FromString(s2)
+	c.Assert(err, IsNil)
+	c.Assert(u2, Equals, u)
+
+	u3, err := FromString(s3)
+	c.Assert(err, IsNil)
+	c.Assert(u3, Equals, u)
+
+	u4, err := FromString(s4)
+	c.Assert(err, IsNil)
+	c.Assert(u4, Equals, u)
+
+	u5, err := FromString(s5)
+	c.Assert(err, IsNil)
+	c.Assert(u5, Equals, u)
+}
+
+func (s *codecTestSuite) BenchmarkFromString(c *C) {
+	str := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	for i := 0; i < c.N; i++ {
+		FromString(str)
+	}
+}
+
+func (s *codecTestSuite) BenchmarkFromStringUrn(c *C) {
+	str := "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	for i := 0; i < c.N; i++ {
+		FromString(str)
+	}
+}
+
+func (s *codecTestSuite) BenchmarkFromStringWithBrackets(c *C) {
+	str := "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}"
+	for i := 0; i < c.N; i++ {
+		FromString(str)
+	}
+}
+
+func (s *codecTestSuite) TestFromStringShort(c *C) {
+	// Invalid 35-character UUID string
+	s1 := "6ba7b810-9dad-11d1-80b4-00c04fd430c"
+
+	for i := len(s1); i >= 0; i-- {
+		_, err := FromString(s1[:i])
+		c.Assert(err, NotNil)
+	}
+}
+
+func (s *codecTestSuite) TestFromStringLong(c *C) {
+	// Invalid 37+ character UUID string
+	strings := []string{
+		"6ba7b810-9dad-11d1-80b4-00c04fd430c8=",
+		"6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
+		"{6ba7b810-9dad-11d1-80b4-00c04fd430c8}f",
+		"6ba7b810-9dad-11d1-80b4-00c04fd430c800c04fd430c8",
+	}
+
+	for _, str := range strings {
+		_, err := FromString(str)
+		c.Assert(err, NotNil)
+	}
+}
+
+func (s *codecTestSuite) TestFromStringInvalid(c *C) {
+	// Invalid UUID string formats
+	strings := []string{
+		"6ba7b8109dad11d180b400c04fd430c86ba7b8109dad11d180b400c04fd430c8",
+		"urn:uuid:{6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
+		"uuid:urn:6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+		"uuid:urn:6ba7b8109dad11d180b400c04fd430c8",
+		"6ba7b8109-dad-11d1-80b4-00c04fd430c8",
+		"6ba7b810-9dad1-1d1-80b4-00c04fd430c8",
+		"6ba7b810-9dad-11d18-0b4-00c04fd430c8",
+		"6ba7b810-9dad-11d1-80b40-0c04fd430c8",
+		"6ba7b810+9dad+11d1+80b4+00c04fd430c8",
+		"(6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
+		"{6ba7b810-9dad-11d1-80b4-00c04fd430c8>",
+		"zba7b810-9dad-11d1-80b4-00c04fd430c8",
+		"6ba7b810-9dad11d180b400c04fd430c8",
+		"6ba7b8109dad-11d180b400c04fd430c8",
+		"6ba7b8109dad11d1-80b400c04fd430c8",
+		"6ba7b8109dad11d180b4-00c04fd430c8",
+	}
+
+	for _, str := range strings {
+		_, err := FromString(str)
+		c.Assert(err, NotNil)
+	}
+}
+
+func (s *codecTestSuite) TestFromStringOrNil(c *C) {
+	u := FromStringOrNil("")
+	c.Assert(u, Equals, Nil)
+}
+
+func (s *codecTestSuite) TestFromBytesOrNil(c *C) {
+	b := []byte{}
+	u := FromBytesOrNil(b)
+	c.Assert(u, Equals, Nil)
+}
+
+func (s *codecTestSuite) TestMarshalText(c *C) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b1 := []byte("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+	b2, err := u.MarshalText()
+	c.Assert(err, IsNil)
+	c.Assert(bytes.Equal(b1, b2), Equals, true)
+}
+
+func (s *codecTestSuite) BenchmarkMarshalText(c *C) {
+	u := NewV4()
+	for i := 0; i < c.N; i++ {
+		u.MarshalText()
+	}
+}
+
+func (s *codecTestSuite) TestUnmarshalText(c *C) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b1 := []byte("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+	u1 := UUID{}
+	err := u1.UnmarshalText(b1)
+	c.Assert(err, IsNil)
+	c.Assert(u1, Equals, u)
+
+	b2 := []byte("")
+	u2 := UUID{}
+	err = u2.UnmarshalText(b2)
+	c.Assert(err, NotNil)
+}
+
+func (s *codecTestSuite) BenchmarkUnmarshalText(c *C) {
+	bytes := []byte("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	u := UUID{}
+	for i := 0; i < c.N; i++ {
+		u.UnmarshalText(bytes)
+	}
+}
+
+var sink string
+
+func (s *codecTestSuite) BenchmarkMarshalToString(c *C) {
+	u := NewV4()
+	for i := 0; i < c.N; i++ {
+		sink = u.String()
+	}
+}

--- a/vendor/github.com/satori/go.uuid/generator.go
+++ b/vendor/github.com/satori/go.uuid/generator.go
@@ -1,0 +1,239 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package uuid
+
+import (
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/binary"
+	"hash"
+	"net"
+	"os"
+	"sync"
+	"time"
+)
+
+// Difference in 100-nanosecond intervals between
+// UUID epoch (October 15, 1582) and Unix epoch (January 1, 1970).
+const epochStart = 122192928000000000
+
+var (
+	global = newDefaultGenerator()
+
+	epochFunc = unixTimeFunc
+	posixUID  = uint32(os.Getuid())
+	posixGID  = uint32(os.Getgid())
+)
+
+// NewV1 returns UUID based on current timestamp and MAC address.
+func NewV1() UUID {
+	return global.NewV1()
+}
+
+// NewV2 returns DCE Security UUID based on POSIX UID/GID.
+func NewV2(domain byte) UUID {
+	return global.NewV2(domain)
+}
+
+// NewV3 returns UUID based on MD5 hash of namespace UUID and name.
+func NewV3(ns UUID, name string) UUID {
+	return global.NewV3(ns, name)
+}
+
+// NewV4 returns random generated UUID.
+func NewV4() UUID {
+	return global.NewV4()
+}
+
+// NewV5 returns UUID based on SHA-1 hash of namespace UUID and name.
+func NewV5(ns UUID, name string) UUID {
+	return global.NewV5(ns, name)
+}
+
+// Generator provides interface for generating UUIDs.
+type Generator interface {
+	NewV1() UUID
+	NewV2(domain byte) UUID
+	NewV3(ns UUID, name string) UUID
+	NewV4() UUID
+	NewV5(ns UUID, name string) UUID
+}
+
+// Default generator implementation.
+type generator struct {
+	storageOnce  sync.Once
+	storageMutex sync.Mutex
+
+	lastTime      uint64
+	clockSequence uint16
+	hardwareAddr  [6]byte
+}
+
+func newDefaultGenerator() Generator {
+	return &generator{}
+}
+
+// NewV1 returns UUID based on current timestamp and MAC address.
+func (g *generator) NewV1() UUID {
+	u := UUID{}
+
+	timeNow, clockSeq, hardwareAddr := g.getStorage()
+
+	binary.BigEndian.PutUint32(u[0:], uint32(timeNow))
+	binary.BigEndian.PutUint16(u[4:], uint16(timeNow>>32))
+	binary.BigEndian.PutUint16(u[6:], uint16(timeNow>>48))
+	binary.BigEndian.PutUint16(u[8:], clockSeq)
+
+	copy(u[10:], hardwareAddr)
+
+	u.SetVersion(V1)
+	u.SetVariant(VariantRFC4122)
+
+	return u
+}
+
+// NewV2 returns DCE Security UUID based on POSIX UID/GID.
+func (g *generator) NewV2(domain byte) UUID {
+	u := UUID{}
+
+	timeNow, clockSeq, hardwareAddr := g.getStorage()
+
+	switch domain {
+	case DomainPerson:
+		binary.BigEndian.PutUint32(u[0:], posixUID)
+	case DomainGroup:
+		binary.BigEndian.PutUint32(u[0:], posixGID)
+	}
+
+	binary.BigEndian.PutUint16(u[4:], uint16(timeNow>>32))
+	binary.BigEndian.PutUint16(u[6:], uint16(timeNow>>48))
+	binary.BigEndian.PutUint16(u[8:], clockSeq)
+	u[9] = domain
+
+	copy(u[10:], hardwareAddr)
+
+	u.SetVersion(V2)
+	u.SetVariant(VariantRFC4122)
+
+	return u
+}
+
+// NewV3 returns UUID based on MD5 hash of namespace UUID and name.
+func (g *generator) NewV3(ns UUID, name string) UUID {
+	u := newFromHash(md5.New(), ns, name)
+	u.SetVersion(V3)
+	u.SetVariant(VariantRFC4122)
+
+	return u
+}
+
+// NewV4 returns random generated UUID.
+func (g *generator) NewV4() UUID {
+	u := UUID{}
+	g.safeRandom(u[:])
+	u.SetVersion(V4)
+	u.SetVariant(VariantRFC4122)
+
+	return u
+}
+
+// NewV5 returns UUID based on SHA-1 hash of namespace UUID and name.
+func (g *generator) NewV5(ns UUID, name string) UUID {
+	u := newFromHash(sha1.New(), ns, name)
+	u.SetVersion(V5)
+	u.SetVariant(VariantRFC4122)
+
+	return u
+}
+
+func (g *generator) initStorage() {
+	g.initClockSequence()
+	g.initHardwareAddr()
+}
+
+func (g *generator) initClockSequence() {
+	buf := make([]byte, 2)
+	g.safeRandom(buf)
+	g.clockSequence = binary.BigEndian.Uint16(buf)
+}
+
+func (g *generator) initHardwareAddr() {
+	interfaces, err := net.Interfaces()
+	if err == nil {
+		for _, iface := range interfaces {
+			if len(iface.HardwareAddr) >= 6 {
+				copy(g.hardwareAddr[:], iface.HardwareAddr)
+				return
+			}
+		}
+	}
+
+	// Initialize hardwareAddr randomly in case
+	// of real network interfaces absence
+	g.safeRandom(g.hardwareAddr[:])
+
+	// Set multicast bit as recommended in RFC 4122
+	g.hardwareAddr[0] |= 0x01
+}
+
+func (g *generator) safeRandom(dest []byte) {
+	if _, err := rand.Read(dest); err != nil {
+		panic(err)
+	}
+}
+
+// Returns UUID v1/v2 storage state.
+// Returns epoch timestamp, clock sequence, and hardware address.
+func (g *generator) getStorage() (uint64, uint16, []byte) {
+	g.storageOnce.Do(g.initStorage)
+
+	g.storageMutex.Lock()
+	defer g.storageMutex.Unlock()
+
+	timeNow := epochFunc()
+	// Clock changed backwards since last UUID generation.
+	// Should increase clock sequence.
+	if timeNow <= g.lastTime {
+		g.clockSequence++
+	}
+	g.lastTime = timeNow
+
+	return timeNow, g.clockSequence, g.hardwareAddr[:]
+}
+
+// Returns difference in 100-nanosecond intervals between
+// UUID epoch (October 15, 1582) and current time.
+// This is default epoch calculation function.
+func unixTimeFunc() uint64 {
+	return epochStart + uint64(time.Now().UnixNano()/100)
+}
+
+// Returns UUID based on hashing of namespace UUID and name.
+func newFromHash(h hash.Hash, ns UUID, name string) UUID {
+	u := UUID{}
+	h.Write(ns[:])
+	h.Write([]byte(name))
+	copy(u[:], h.Sum(nil))
+
+	return u
+}

--- a/vendor/github.com/satori/go.uuid/generator_test.go
+++ b/vendor/github.com/satori/go.uuid/generator_test.go
@@ -1,0 +1,134 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package uuid
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type genTestSuite struct{}
+
+var _ = Suite(&genTestSuite{})
+
+func (s *genTestSuite) TestNewV1(c *C) {
+	u := NewV1()
+	c.Assert(u.Version(), Equals, V1)
+	c.Assert(u.Variant(), Equals, VariantRFC4122)
+
+	u1 := NewV1()
+	u2 := NewV1()
+	c.Assert(u1, Not(Equals), u2)
+
+	oldFunc := epochFunc
+	epochFunc = func() uint64 { return 0 }
+
+	u3 := NewV1()
+	u4 := NewV1()
+	c.Assert(u3, Not(Equals), u4)
+
+	epochFunc = oldFunc
+}
+
+func (s *genTestSuite) BenchmarkNewV1(c *C) {
+	for i := 0; i < c.N; i++ {
+		NewV1()
+	}
+}
+
+func (s *genTestSuite) TestNewV2(c *C) {
+	u1 := NewV2(DomainPerson)
+	c.Assert(u1.Version(), Equals, V2)
+	c.Assert(u1.Variant(), Equals, VariantRFC4122)
+
+	u2 := NewV2(DomainGroup)
+	c.Assert(u2.Version(), Equals, V2)
+	c.Assert(u2.Variant(), Equals, VariantRFC4122)
+}
+
+func (s *genTestSuite) BenchmarkNewV2(c *C) {
+	for i := 0; i < c.N; i++ {
+		NewV2(DomainPerson)
+	}
+}
+
+func (s *genTestSuite) TestNewV3(c *C) {
+	u := NewV3(NamespaceDNS, "www.example.com")
+	c.Assert(u.Version(), Equals, V3)
+	c.Assert(u.Variant(), Equals, VariantRFC4122)
+	c.Assert(u.String(), Equals, "5df41881-3aed-3515-88a7-2f4a814cf09e")
+
+	u = NewV3(NamespaceDNS, "python.org")
+	c.Assert(u.String(), Equals, "6fa459ea-ee8a-3ca4-894e-db77e160355e")
+
+	u1 := NewV3(NamespaceDNS, "golang.org")
+	u2 := NewV3(NamespaceDNS, "golang.org")
+	c.Assert(u1, Equals, u2)
+
+	u3 := NewV3(NamespaceDNS, "example.com")
+	c.Assert(u1, Not(Equals), u3)
+
+	u4 := NewV3(NamespaceURL, "golang.org")
+	c.Assert(u1, Not(Equals), u4)
+}
+
+func (s *genTestSuite) BenchmarkNewV3(c *C) {
+	for i := 0; i < c.N; i++ {
+		NewV3(NamespaceDNS, "www.example.com")
+	}
+}
+
+func (s *genTestSuite) TestNewV4(c *C) {
+	u := NewV4()
+	c.Assert(u.Version(), Equals, V4)
+	c.Assert(u.Variant(), Equals, VariantRFC4122)
+}
+
+func (s *genTestSuite) BenchmarkNewV4(c *C) {
+	for i := 0; i < c.N; i++ {
+		NewV4()
+	}
+}
+
+func (s *genTestSuite) TestNewV5(c *C) {
+	u := NewV5(NamespaceDNS, "www.example.com")
+	c.Assert(u.Version(), Equals, V5)
+	c.Assert(u.Variant(), Equals, VariantRFC4122)
+
+	u = NewV5(NamespaceDNS, "python.org")
+	c.Assert(u.String(), Equals, "886313e1-3b8a-5372-9b90-0c9aee199e5d")
+
+	u1 := NewV5(NamespaceDNS, "golang.org")
+	u2 := NewV5(NamespaceDNS, "golang.org")
+	c.Assert(u1, Equals, u2)
+
+	u3 := NewV5(NamespaceDNS, "example.com")
+	c.Assert(u1, Not(Equals), u3)
+
+	u4 := NewV5(NamespaceURL, "golang.org")
+	c.Assert(u1, Not(Equals), u4)
+}
+
+func (s *genTestSuite) BenchmarkNewV5(c *C) {
+	for i := 0; i < c.N; i++ {
+		NewV5(NamespaceDNS, "www.example.com")
+	}
+}

--- a/vendor/github.com/satori/go.uuid/sql.go
+++ b/vendor/github.com/satori/go.uuid/sql.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package uuid
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+// Value implements the driver.Valuer interface.
+func (u UUID) Value() (driver.Value, error) {
+	return u.String(), nil
+}
+
+// Scan implements the sql.Scanner interface.
+// A 16-byte slice is handled by UnmarshalBinary, while
+// a longer byte slice or a string is handled by UnmarshalText.
+func (u *UUID) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		if len(src) == Size {
+			return u.UnmarshalBinary(src)
+		}
+		return u.UnmarshalText(src)
+
+	case string:
+		return u.UnmarshalText([]byte(src))
+	}
+
+	return fmt.Errorf("uuid: cannot convert %T to UUID", src)
+}
+
+// NullUUID can be used with the standard sql package to represent a
+// UUID value that can be NULL in the database
+type NullUUID struct {
+	UUID  UUID
+	Valid bool
+}
+
+// Value implements the driver.Valuer interface.
+func (u NullUUID) Value() (driver.Value, error) {
+	if !u.Valid {
+		return nil, nil
+	}
+	// Delegate to UUID Value function
+	return u.UUID.Value()
+}
+
+// Scan implements the sql.Scanner interface.
+func (u *NullUUID) Scan(src interface{}) error {
+	if src == nil {
+		u.UUID, u.Valid = Nil, false
+		return nil
+	}
+
+	// Delegate to UUID Scan function
+	u.Valid = true
+	return u.UUID.Scan(src)
+}

--- a/vendor/github.com/satori/go.uuid/sql_test.go
+++ b/vendor/github.com/satori/go.uuid/sql_test.go
@@ -1,0 +1,136 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package uuid
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type sqlTestSuite struct{}
+
+var _ = Suite(&sqlTestSuite{})
+
+func (s *sqlTestSuite) TestValue(c *C) {
+	u, err := FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	c.Assert(err, IsNil)
+
+	val, err := u.Value()
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, u.String())
+}
+
+func (s *sqlTestSuite) TestValueNil(c *C) {
+	u := UUID{}
+
+	val, err := u.Value()
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, Nil.String())
+}
+
+func (s *sqlTestSuite) TestNullUUIDValueNil(c *C) {
+	u := NullUUID{}
+
+	val, err := u.Value()
+	c.Assert(err, IsNil)
+	c.Assert(val, IsNil)
+}
+
+func (s *sqlTestSuite) TestScanBinary(c *C) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b1 := []byte{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	u1 := UUID{}
+	err := u1.Scan(b1)
+	c.Assert(err, IsNil)
+	c.Assert(u, Equals, u1)
+
+	b2 := []byte{}
+	u2 := UUID{}
+
+	err = u2.Scan(b2)
+	c.Assert(err, NotNil)
+}
+
+func (s *sqlTestSuite) TestScanString(c *C) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	s1 := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+	u1 := UUID{}
+	err := u1.Scan(s1)
+	c.Assert(err, IsNil)
+	c.Assert(u, Equals, u1)
+
+	s2 := ""
+	u2 := UUID{}
+
+	err = u2.Scan(s2)
+	c.Assert(err, NotNil)
+}
+
+func (s *sqlTestSuite) TestScanText(c *C) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b1 := []byte("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+	u1 := UUID{}
+	err := u1.Scan(b1)
+	c.Assert(err, IsNil)
+	c.Assert(u, Equals, u1)
+
+	b2 := []byte("")
+	u2 := UUID{}
+	err = u2.Scan(b2)
+	c.Assert(err, NotNil)
+}
+
+func (s *sqlTestSuite) TestScanUnsupported(c *C) {
+	u := UUID{}
+
+	err := u.Scan(true)
+	c.Assert(err, NotNil)
+}
+
+func (s *sqlTestSuite) TestScanNil(c *C) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	err := u.Scan(nil)
+	c.Assert(err, NotNil)
+}
+
+func (s *sqlTestSuite) TestNullUUIDScanValid(c *C) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	s1 := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+	u1 := NullUUID{}
+	err := u1.Scan(s1)
+	c.Assert(err, IsNil)
+	c.Assert(u1.Valid, Equals, true)
+	c.Assert(u1.UUID, Equals, u)
+}
+
+func (s *sqlTestSuite) TestNullUUIDScanNil(c *C) {
+	u := NullUUID{UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}, true}
+
+	err := u.Scan(nil)
+	c.Assert(err, IsNil)
+	c.Assert(u.Valid, Equals, false)
+	c.Assert(u.UUID, Equals, Nil)
+}

--- a/vendor/github.com/satori/go.uuid/uuid.go
+++ b/vendor/github.com/satori/go.uuid/uuid.go
@@ -1,0 +1,161 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Package uuid provides implementation of Universally Unique Identifier (UUID).
+// Supported versions are 1, 3, 4 and 5 (as specified in RFC 4122) and
+// version 2 (as specified in DCE 1.1).
+package uuid
+
+import (
+	"bytes"
+	"encoding/hex"
+)
+
+// Size of a UUID in bytes.
+const Size = 16
+
+// UUID representation compliant with specification
+// described in RFC 4122.
+type UUID [Size]byte
+
+// UUID versions
+const (
+	_ byte = iota
+	V1
+	V2
+	V3
+	V4
+	V5
+)
+
+// UUID layout variants.
+const (
+	VariantNCS byte = iota
+	VariantRFC4122
+	VariantMicrosoft
+	VariantFuture
+)
+
+// UUID DCE domains.
+const (
+	DomainPerson = iota
+	DomainGroup
+	DomainOrg
+)
+
+// String parse helpers.
+var (
+	urnPrefix  = []byte("urn:uuid:")
+	byteGroups = []int{8, 4, 4, 4, 12}
+)
+
+// Nil is special form of UUID that is specified to have all
+// 128 bits set to zero.
+var Nil = UUID{}
+
+// Predefined namespace UUIDs.
+var (
+	NamespaceDNS  = Must(FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"))
+	NamespaceURL  = Must(FromString("6ba7b811-9dad-11d1-80b4-00c04fd430c8"))
+	NamespaceOID  = Must(FromString("6ba7b812-9dad-11d1-80b4-00c04fd430c8"))
+	NamespaceX500 = Must(FromString("6ba7b814-9dad-11d1-80b4-00c04fd430c8"))
+)
+
+// Equal returns true if u1 and u2 equals, otherwise returns false.
+func Equal(u1 UUID, u2 UUID) bool {
+	return bytes.Equal(u1[:], u2[:])
+}
+
+// Version returns algorithm version used to generate UUID.
+func (u UUID) Version() byte {
+	return u[6] >> 4
+}
+
+// Variant returns UUID layout variant.
+func (u UUID) Variant() byte {
+	switch {
+	case (u[8] >> 7) == 0x00:
+		return VariantNCS
+	case (u[8] >> 6) == 0x02:
+		return VariantRFC4122
+	case (u[8] >> 5) == 0x06:
+		return VariantMicrosoft
+	case (u[8] >> 5) == 0x07:
+		fallthrough
+	default:
+		return VariantFuture
+	}
+}
+
+// Bytes returns bytes slice representation of UUID.
+func (u UUID) Bytes() []byte {
+	return u[:]
+}
+
+// Returns canonical string representation of UUID:
+// xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
+func (u UUID) String() string {
+	buf := make([]byte, 36)
+
+	hex.Encode(buf[0:8], u[0:4])
+	buf[8] = '-'
+	hex.Encode(buf[9:13], u[4:6])
+	buf[13] = '-'
+	hex.Encode(buf[14:18], u[6:8])
+	buf[18] = '-'
+	hex.Encode(buf[19:23], u[8:10])
+	buf[23] = '-'
+	hex.Encode(buf[24:], u[10:])
+
+	return string(buf)
+}
+
+// SetVersion sets version bits.
+func (u *UUID) SetVersion(v byte) {
+	u[6] = (u[6] & 0x0f) | (v << 4)
+}
+
+// SetVariant sets variant bits.
+func (u *UUID) SetVariant(v byte) {
+	switch v {
+	case VariantNCS:
+		u[8] = (u[8]&(0xff>>1) | (0x00 << 7))
+	case VariantRFC4122:
+		u[8] = (u[8]&(0xff>>2) | (0x02 << 6))
+	case VariantMicrosoft:
+		u[8] = (u[8]&(0xff>>3) | (0x06 << 5))
+	case VariantFuture:
+		fallthrough
+	default:
+		u[8] = (u[8]&(0xff>>3) | (0x07 << 5))
+	}
+}
+
+// Must is a helper that wraps a call to a function returning (UUID, error)
+// and panics if the error is non-nil. It is intended for use in variable
+// initializations such as
+//	var packageUUID = uuid.Must(uuid.FromString("123e4567-e89b-12d3-a456-426655440000"));
+func Must(u UUID, err error) UUID {
+	if err != nil {
+		panic(err)
+	}
+	return u
+}

--- a/vendor/github.com/satori/go.uuid/uuid_test.go
+++ b/vendor/github.com/satori/go.uuid/uuid_test.go
@@ -1,0 +1,90 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package uuid
+
+import (
+	"bytes"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func TestUUID(t *testing.T) { TestingT(t) }
+
+type testSuite struct{}
+
+var _ = Suite(&testSuite{})
+
+func (s *testSuite) TestBytes(c *C) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	bytes1 := []byte{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	c.Assert(bytes.Equal(u.Bytes(), bytes1), Equals, true)
+}
+
+func (s *testSuite) TestString(c *C) {
+	c.Assert(NamespaceDNS.String(), Equals, "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+}
+
+func (s *testSuite) TestEqual(c *C) {
+	c.Assert(Equal(NamespaceDNS, NamespaceDNS), Equals, true)
+	c.Assert(Equal(NamespaceDNS, NamespaceURL), Equals, false)
+}
+
+func (s *testSuite) TestVersion(c *C) {
+	u := UUID{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	c.Assert(u.Version(), Equals, V1)
+}
+
+func (s *testSuite) TestSetVersion(c *C) {
+	u := UUID{}
+	u.SetVersion(4)
+	c.Assert(u.Version(), Equals, V4)
+}
+
+func (s *testSuite) TestVariant(c *C) {
+	u1 := UUID{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	c.Assert(u1.Variant(), Equals, VariantNCS)
+
+	u2 := UUID{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	c.Assert(u2.Variant(), Equals, VariantRFC4122)
+
+	u3 := UUID{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	c.Assert(u3.Variant(), Equals, VariantMicrosoft)
+
+	u4 := UUID{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	c.Assert(u4.Variant(), Equals, VariantFuture)
+}
+
+func (s *testSuite) TestSetVariant(c *C) {
+	u := UUID{}
+	u.SetVariant(VariantNCS)
+	c.Assert(u.Variant(), Equals, VariantNCS)
+	u.SetVariant(VariantRFC4122)
+	c.Assert(u.Variant(), Equals, VariantRFC4122)
+	u.SetVariant(VariantMicrosoft)
+	c.Assert(u.Variant(), Equals, VariantMicrosoft)
+	u.SetVariant(VariantFuture)
+	c.Assert(u.Variant(), Equals, VariantFuture)
+}


### PR DESCRIPTION
Feature: Code generation for Implementation through Excel sheet and input profile. 
Uses package  https://github.com/satori/go.uuid to generate GUIDs
Usage: `oscalkit implementation -p path-to-profile -e path-to-excelsheet.csv`